### PR TITLE
A bit smarter cursor position

### DIFF
--- a/TestNameGenerator.py
+++ b/TestNameGenerator.py
@@ -53,6 +53,7 @@ class ConvertTestNameCommand(sublime_plugin.TextCommand):
 
                 if existingMethod == False:
                     SublimeConnect.insertMethodName(edit, cursorLine, TextHelper.prepareTestBlockPHP(phrase, methodName))
+                    self.view.run_command("insert_snippet", {"contents": "\n\{\n\t$5\n\}"})
                 else:
                     SublimeConnect.updateMethodNamePHP(edit, cursorLine, methodName, existingMethod)
 
@@ -73,7 +74,7 @@ class TextHelper():
 
     def prepareTestBlockPHP(phrase, methodName):
         tab = SublimeConnect.getWhitespaceTab()
-        return tab + "/**\n" + tab + " * " + phrase + "\n" + tab + " */\n" + tab + "public function test" + methodName + "()\n" + tab + "{\n\n" + tab + "}\n\n" + tab
+        return tab + "/**\n" + tab + " * " + phrase + "\n" + tab + " */\n" + tab + "public function test" + methodName + "()"
 
     # will generate Jasmine blocks
     def prepareTestBlockJS(phrase):


### PR DESCRIPTION
Let's put the cursor in the middle of the method, not at the end, shall we? :)

```
	/**
	 * foo
	 */
	public function testFoo()
	{
		// cursor is placed here
	}
```

(probably not the best solution, but it works)